### PR TITLE
Port to rules-based world, compatible with Bazel 7-9.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /bazel-*
 /external
 /compile_commands.json
-
+# Ignore the Bazel lock file.
+# This project has basically no dependencies, it just creates noise.
+/MODULE.bazel.lock

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 licenses(["notice"])
 
 cc_library(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,6 @@
+module(
+    name = "static-functional",
+    version = "1.0.0-alpha"
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.16")


### PR DESCRIPTION
This change makes the codebase compatible with Bazel 9 which requires the starlark-based build rules. It is also compatible with Bazel 7 and 8, though this PR would drop support for older versions as I deleted the WORKSPACE file. Restoring it would not fix it, as we would have to explicitly depend on `rules_cc` from WORKSPACE, but if you have a version that you think should still work in mind I am happy to take a look.

Given the minimal setup here, I opted not to commit the `MODULE.bazel.lock` file, but happy to do so.